### PR TITLE
Fix base URL for DeepSeek API

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -52,7 +52,7 @@ export QDRANT_COLLECTION="running_coach_memories"
 ### DeepSeek API
 ```bash
 export DEEPSEEK_API_KEY="your-deepseek-key"
-export DEEPSEEK_BASE_URL="https://api.deepseek.com"
+export DEEPSEEK_BASE_URL="https://api.deepseek.com/v1"
 export DEEPSEEK_MODEL="deepseek-chat"
 ```
 

--- a/apps/api-gateway/src/app.ts
+++ b/apps/api-gateway/src/app.ts
@@ -112,7 +112,7 @@ function loadConfig(): Config {
     QDRANT_API_KEY: process.env.QDRANT_API_KEY,
     QDRANT_COLLECTION: process.env.QDRANT_COLLECTION || 'running_coach_memories',
     DEEPSEEK_API_KEY: process.env.DEEPSEEK_API_KEY!,
-    DEEPSEEK_BASE_URL: process.env.DEEPSEEK_BASE_URL || 'https://api.deepseek.com',
+    DEEPSEEK_BASE_URL: process.env.DEEPSEEK_BASE_URL || 'https://api.deepseek.com/v1',
     DEEPSEEK_MODEL: process.env.DEEPSEEK_MODEL || 'deepseek-chat',
     JWT_TOKEN: process.env.JWT_TOKEN!,
     NUMBER_ID: process.env.NUMBER_ID!,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -15,7 +15,7 @@ const getApiKey = () => {
 
 // Validate and get base URL
 const getBaseUrl = () => {
-  const url = process.env.baseURL || "https://api.deepseek.com";
+  const url = process.env.baseURL || "https://api.deepseek.com/v1";
   console.log("🔗 Using API URL:", url);
   return url;
 };


### PR DESCRIPTION
## Summary
- update default DeepSeek base URL to include `/v1`
- fix env example in deployment docs

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68606114f2508328858e9d825d0e33a0