### PR TITLE
Enable separate OpenAI embeddings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,11 @@ DEEPSEEK_API_KEY=YOUR_API_KEY_HERE
 DEEPSEEK_BASE_URL=https://api.deepseek.com/v1
 DEEPSEEK_MODEL=deepseek-chat
 
+# OpenAI Embeddings
+EMBEDDINGS_API_KEY=your_openai_api_key
+EMBEDDINGS_BASE_URL=https://api.openai.com/v1
+EMBEDDINGS_MODEL=text-embedding-ada-002
+
 # Meta WhatsApp API
 jwtToken=YOUR_JWT_TOKEN_HERE
 numberId=YOUR_NUMBER_ID_HERE

--- a/apps/api-gateway/src/app.ts
+++ b/apps/api-gateway/src/app.ts
@@ -74,6 +74,9 @@ interface Config {
   DEEPSEEK_API_KEY: string;
   DEEPSEEK_BASE_URL: string;
   DEEPSEEK_MODEL: string;
+  EMBEDDINGS_API_KEY: string;
+  EMBEDDINGS_BASE_URL: string;
+  EMBEDDINGS_MODEL: string;
   
   // WhatsApp
   JWT_TOKEN: string;
@@ -92,6 +95,7 @@ function loadConfig(): Config {
     'REDIS_HOST',
     'QDRANT_URL',
     'DEEPSEEK_API_KEY',
+    'EMBEDDINGS_API_KEY',
     'JWT_TOKEN',
     'NUMBER_ID',
     'VERIFY_TOKEN'
@@ -114,6 +118,9 @@ function loadConfig(): Config {
     DEEPSEEK_API_KEY: process.env.DEEPSEEK_API_KEY!,
     DEEPSEEK_BASE_URL: process.env.DEEPSEEK_BASE_URL || 'https://api.deepseek.com/v1',
     DEEPSEEK_MODEL: process.env.DEEPSEEK_MODEL || 'deepseek-chat',
+    EMBEDDINGS_API_KEY: process.env.EMBEDDINGS_API_KEY!,
+    EMBEDDINGS_BASE_URL: process.env.EMBEDDINGS_BASE_URL || 'https://api.openai.com/v1',
+    EMBEDDINGS_MODEL: process.env.EMBEDDINGS_MODEL || 'text-embedding-ada-002',
     JWT_TOKEN: process.env.JWT_TOKEN!,
     NUMBER_ID: process.env.NUMBER_ID!,
     VERIFY_TOKEN: process.env.VERIFY_TOKEN!,
@@ -159,8 +166,9 @@ async function initializeServices(config: Config) {
       collectionName: config.QDRANT_COLLECTION
     },
     {
-      apiKey: config.DEEPSEEK_API_KEY,
-      baseURL: config.DEEPSEEK_BASE_URL
+      apiKey: config.EMBEDDINGS_API_KEY,
+      baseURL: config.EMBEDDINGS_BASE_URL,
+      model: config.EMBEDDINGS_MODEL
     }
   );
   await vectorMemory.initialize();

--- a/packages/vector-memory/src/vector-memory.ts
+++ b/packages/vector-memory/src/vector-memory.ts
@@ -28,6 +28,7 @@ export class VectorMemory {
   private qdrant: QdrantClient;
   private openai: OpenAI;
   private collectionName: string;
+  private embeddingModel: string;
 
   private constructor(qdrantConfig: QdrantConfig, openaiConfig: OpenAIConfig) {
     this.qdrant = new QdrantClient({
@@ -39,6 +40,8 @@ export class VectorMemory {
       apiKey: openaiConfig.apiKey,
       baseURL: openaiConfig.baseURL,
     });
+
+    this.embeddingModel = openaiConfig.model || 'text-embedding-ada-002';
 
     this.collectionName = qdrantConfig.collectionName;
   }
@@ -264,7 +267,7 @@ export class VectorMemory {
   private async generateEmbedding(text: string): Promise<number[]> {
     try {
       const response = await this.openai.embeddings.create({
-        model: 'text-embedding-ada-002',
+        model: this.embeddingModel,
         input: text,
       });
       return response.data[0].embedding;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -23,6 +23,14 @@ const getBaseUrl = () => {
   return url;
 };
 
+const getEmbeddingsConfig = () => {
+  return {
+    embeddingsApiKey: process.env.EMBEDDINGS_API_KEY,
+    embeddingsBaseUrl: process.env.EMBEDDINGS_BASE_URL || 'https://api.openai.com/v1',
+    embeddingsModel: process.env.EMBEDDINGS_MODEL || 'text-embedding-ada-002'
+  };
+};
+
 // Validate Meta credentials
 const getMetaCredentials = () => {
   const jwtToken = process.env.jwtToken;
@@ -52,6 +60,9 @@ export interface Config {
   Model: string;
   baseURL: string;
   apiKey?: string;
+  embeddingsApiKey?: string;
+  embeddingsBaseUrl?: string;
+  embeddingsModel?: string;
   assistant_id?: string;
   spreadsheetId?: string;
   trainingSpreadsheetId?: string; // ID de la hoja para registrar entrenamientos
@@ -66,6 +77,7 @@ export const config: Config = {
   Model: process.env.Model || process.env.model || process.env.DEEPSEEK_MODEL || "deepseek-chat",
   baseURL: getBaseUrl(),
   apiKey: getApiKey(),
+  ...getEmbeddingsConfig(),
   assistant_id: process.env.ASSISTANT_ID || process.env.assistant_id,
   spreadsheetId: process.env.spreadsheetId,
   trainingSpreadsheetId: process.env.TRAINING_SPREADSHEET_ID,
@@ -75,19 +87,22 @@ export const config: Config = {
 };
 
 // Verificación de variables críticas
-const requiredVars = {
-  'API Key': config.apiKey,
-  'JWT Token': config.jwtToken,
-  'Number ID': config.numberId,
-  'Verify Token': config.verifyToken,
-  'Spreadsheet ID': config.spreadsheetId,
-  'Training Spreadsheet ID': config.trainingSpreadsheetId,
-  'Private Key': config.privateKey,
-  'Client Email': config.clientEmail,
-  'Calendar ID': config.calendarId,
-  'Base URL': config.baseURL,
-  'Model': config.Model
-};
+  const requiredVars = {
+    'API Key': config.apiKey,
+    'Embeddings API Key': config.embeddingsApiKey,
+    'JWT Token': config.jwtToken,
+    'Number ID': config.numberId,
+    'Verify Token': config.verifyToken,
+    'Spreadsheet ID': config.spreadsheetId,
+    'Training Spreadsheet ID': config.trainingSpreadsheetId,
+    'Private Key': config.privateKey,
+    'Client Email': config.clientEmail,
+    'Calendar ID': config.calendarId,
+    'Base URL': config.baseURL,
+    'Model': config.Model,
+    'Embeddings Base URL': config.embeddingsBaseUrl,
+    'Embeddings Model': config.embeddingsModel
+  };
 
 // Verificar variables críticas
 Object.entries(requiredVars).forEach(([name, value]) => {


### PR DESCRIPTION
## Summary
- add embeddings config variables
- store embedding model in VectorMemory
- load embeddings config in API gateway and pass to VectorMemory

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686151439cc48328b6e1ee3cf75de558