### PR TITLE
Ensure vector index for userId

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -46,6 +46,9 @@ export QDRANT_URL="https://your-cluster.qdrant.io"
 export QDRANT_API_KEY="your-api-key"
 export QDRANT_COLLECTION="running_coach_memories"
 ```
+When the application starts, it ensures a payload index on the `userId` field
+is created for this collection. If the index already exists, initialization
+continues without error.
 
 ## 🤖 AI Services Configuration
 

--- a/packages/vector-memory/src/__tests__/initialize.test.ts
+++ b/packages/vector-memory/src/__tests__/initialize.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { VectorMemory } from '../vector-memory';
+
+const mockClient = {
+  getCollections: vi.fn(),
+  createCollection: vi.fn(),
+  createPayloadIndex: vi.fn(),
+};
+
+vi.mock('@qdrant/js-client-rest', () => ({
+  QdrantClient: vi.fn(() => mockClient),
+}));
+
+vi.mock('@running-coach/shared', () => ({
+  VECTOR_DIMENSION: 1536,
+}));
+
+vi.mock('openai', () => ({
+  default: class {},
+}));
+
+beforeEach(() => {
+  // reset singleton between tests
+  // @ts-ignore
+  VectorMemory.instance = undefined;
+  mockClient.getCollections.mockResolvedValue({ collections: [] });
+  mockClient.createCollection.mockResolvedValue({});
+  mockClient.createPayloadIndex.mockResolvedValue({});
+});
+
+describe('VectorMemory.initialize', () => {
+  it('creates payload index for userId', async () => {
+    const vm = VectorMemory.getInstance(
+      { url: 'http://localhost:6333', collectionName: 'test' },
+      { apiKey: 'test-key' }
+    );
+    await vm.initialize();
+    expect(mockClient.createPayloadIndex).toHaveBeenCalledWith('test', {
+      field_name: 'userId',
+      field_schema: 'uuid',
+      wait: true,
+    });
+  });
+});

--- a/packages/vector-memory/src/vector-memory.ts
+++ b/packages/vector-memory/src/vector-memory.ts
@@ -97,6 +97,25 @@ export class VectorMemory {
       } else {
         console.log(`✅ Qdrant collection already exists: ${this.collectionName}`);
       }
+
+      // Ensure payload index on userId exists
+      try {
+        await this.qdrant.createPayloadIndex(this.collectionName, {
+          field_name: 'userId',
+          field_schema: 'uuid',
+          wait: true,
+        });
+        console.log('✅ Created userId payload index');
+      } catch (indexError: any) {
+        if (
+          indexError?.message?.includes('already exists') ||
+          indexError?.response?.status === 409
+        ) {
+          console.log('ℹ️ userId payload index already exists');
+        } else {
+          console.error('❌ Error creating userId payload index:', indexError);
+        }
+      }
     } catch (error) {
       console.error('❌ Error initializing vector memory:', error);
       throw error;


### PR DESCRIPTION
## Summary
- add payload index creation on `userId` when initializing vector memory
- handle existing index gracefully
- document new behaviour in deployment notes
- test that initialization creates the index

## Testing
- `pnpm --filter vector-memory lint`
- `pnpm --filter vector-memory type-check`
- `CI=1 pnpm --filter vector-memory test`

------
https://chatgpt.com/codex/tasks/task_e_68659f5925488328907ee99ec66dffdb