### PR TITLE
Add DB verification script and concise AI replies

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -83,7 +83,7 @@ pnpm --filter database tsx src/migrate-from-sheets.ts
 ### 2. Verify Migration
 ```bash
 # Check data integrity
-pnpm --filter database tsx src/verify-migration.ts
+pnpm --filter database verify
 ```
 
 ## 🚀 Railway Deployment

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -11,7 +11,8 @@
     "lint": "eslint src --ext .ts",
     "type-check": "tsc --noEmit",
     "migrate": "tsx src/migrate.ts",
-    "seed": "tsx src/seed.ts"
+    "seed": "tsx src/seed.ts",
+    "verify": "tsx src/verify-migration.ts"
   },
   "dependencies": {
     "@running-coach/shared": "workspace:*",

--- a/packages/database/src/verify-migration.ts
+++ b/packages/database/src/verify-migration.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env tsx
+
+import postgres from 'postgres';
+
+const expectedTables = [
+  'users',
+  'runs',
+  'training_plans',
+  'workouts',
+  'chat_messages',
+  'progress_summaries',
+  'memory_vectors',
+  'appointments'
+];
+
+async function verify() {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error('DATABASE_URL environment variable is required');
+    process.exit(1);
+  }
+
+  const client = postgres(databaseUrl, { max: 1 });
+  try {
+    const rows = await client<{{table_name:string}}>`
+      SELECT table_name FROM information_schema.tables
+      WHERE table_schema = 'public';
+    `;
+    const existing = rows.map(r => r.table_name);
+    const missing = expectedTables.filter(t => !existing.includes(t));
+    if (missing.length === 0) {
+      console.log('✅ All expected tables exist');
+    } else {
+      console.error('❌ Missing tables:', missing.join(', '));
+      process.exit(1);
+    }
+  } catch (error) {
+    console.error('Verification failed:', error);
+    process.exit(1);
+  } finally {
+    await client.end();
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  verify();
+}

--- a/packages/llm-orchestrator/src/ai-agent.ts
+++ b/packages/llm-orchestrator/src/ai-agent.ts
@@ -105,7 +105,7 @@ export class AIAgent {
         tools: tools.length > 0 ? tools : undefined,
         tool_choice: tools.length > 0 ? 'auto' : undefined,
         temperature: 0.7,
-        max_tokens: 1000,
+        max_tokens: 400,
       });
 
       const choice = completion.choices[0];
@@ -159,7 +159,7 @@ export class AIAgent {
             model: this.model,
             messages,
             temperature: 0.7,
-            max_tokens: 1000,
+            max_tokens: 400,
           });
           content = followupCompletion.choices[0].message.content || content;
         }
@@ -202,7 +202,7 @@ export class AIAgent {
         model: this.model,
         messages,
         temperature: 0.7,
-        max_tokens: 1000,
+        max_tokens: 400,
       });
 
       return completion.choices[0].message.content || '';
@@ -270,6 +270,7 @@ export class AIAgent {
 - Suggest concrete next steps
 - Ask follow-up questions to gather more context
 - Use motivational language while being informative
+- Keep replies short and friendly, ideally under three sentences
 
 ## AVAILABLE TOOLS
 You have access to tools for:
@@ -305,6 +306,7 @@ Always use tools when the user provides data or requests specific actions.`;
 - Sugiere pasos concretos a seguir
 - Haz preguntas de seguimiento para obtener más contexto
 - Usa lenguaje motivacional mientras eres informativo
+- Mantén las respuestas cortas y amables, idealmente en menos de tres frases
 
 ## HERRAMIENTAS DISPONIBLES
 Tienes acceso a herramientas para:


### PR DESCRIPTION
## Summary
- add `verify-migration.ts` script to check table existence
- register new script in database package
- reduce max_tokens in AI agent for shorter answers
- add brevity guideline in system prompts
- document verification step in DEPLOYMENT.md

## Testing
- `pnpm --filter llm-orchestrator exec vitest run`
- `pnpm --filter api-gateway exec vitest run`
- `pnpm --filter vector-memory exec vitest run` *(fails: failed to resolve @running-coach/shared)*
- `pnpm --filter plan-generator exec vitest run` *(fails: failed to resolve @running-coach/shared)*
- `pnpm -r lint` *(fails: missing eslint-plugin-builderbot)*

------
https://chatgpt.com/codex/tasks/task_e_6865ddd974fc8328a53a823e20b56dcb