### PR TITLE
Fix database verification generics

### DIFF
--- a/packages/database/src/verify-migration.ts
+++ b/packages/database/src/verify-migration.ts
@@ -22,11 +22,11 @@ async function verify() {
 
   const client = postgres(databaseUrl, { max: 1 });
   try {
-    const rows = await client<{{table_name:string}}>`
+    const rows = await client<{ table_name: string }[]>`
       SELECT table_name FROM information_schema.tables
       WHERE table_schema = 'public';
     `;
-    const existing = rows.map(r => r.table_name);
+    const existing = rows.map((r) => r.table_name);
     const missing = expectedTables.filter(t => !existing.includes(t));
     if (missing.length === 0) {
       console.log('✅ All expected tables exist');


### PR DESCRIPTION
## Summary
- update `verify-migration` generics for postgres client

## Testing
- `pnpm build`
- `CI=true pnpm -r test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6866beb48cec8328be877289c7846fa2