### PR TITLE
Fix verify-migration TypeScript build error

### DIFF
--- a/packages/database/src/verify-migration.ts
+++ b/packages/database/src/verify-migration.ts
@@ -22,10 +22,10 @@ async function verify() {
 
   const client = postgres(databaseUrl, { max: 1 });
   try {
-    const rows = await client<{ table_name: string }[]>`
+    const rows = await client`
       SELECT table_name FROM information_schema.tables
       WHERE table_schema = 'public';
-    `;
+    ` as { table_name: string }[];
     const existing = rows.map((r) => r.table_name);
     const missing = expectedTables.filter(t => !existing.includes(t));
     if (missing.length === 0) {


### PR DESCRIPTION
## Summary
- fix `verify-migration.ts` query syntax to compile with TypeScript

## Testing
- `pnpm build`
- `CI=1 pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_6866c486ef008328a48b81bbf106652c