### PR TITLE
Fix build error in freemium service test

### DIFF
--- a/apps/api-gateway/src/__tests__/freemium-service.test.ts
+++ b/apps/api-gateway/src/__tests__/freemium-service.test.ts
@@ -1,15 +1,16 @@
+import { describe, it, expect, beforeEach, vi, type Mocked } from 'vitest';
 import { FreemiumService } from '../services/freemium-service';
 import { ChatBuffer } from '@running-coach/vector-memory';
 
 describe('FreemiumService', () => {
-  let chatBufferMock: jest.Mocked<ChatBuffer>;
+  let chatBufferMock: Mocked<ChatBuffer>;
   let freemiumService: FreemiumService;
   const MESSAGE_LIMIT = 10;
   const PAYWALL_LINK = 'https://example.com/paywall';
 
   beforeEach(() => {
     chatBufferMock = {
-      incrementKey: jest.fn(),
+      incrementKey: vi.fn(),
     } as any;
     freemiumService = new FreemiumService(chatBufferMock, MESSAGE_LIMIT, PAYWALL_LINK);
   });


### PR DESCRIPTION
## Summary
- update freemium service test to use Vitest APIs

## Testing
- `pnpm -r build`
- `pnpm -r test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_686eb6c1e52c8328aba11bb20b48c4b8