### PR TITLE
Fix onboarding tests after adding new questions

### DIFF
--- a/packages/llm-orchestrator/__tests__/onboarding-agent.test.ts
+++ b/packages/llm-orchestrator/__tests__/onboarding-agent.test.ts
@@ -103,7 +103,7 @@ describe('OnboardingAgent', () => {
     expect(response).toBe('Lo siento, no entendí tu meta de carrera. Por favor, elige entre 5k, 10k, media maraton o maraton.');
     expect(mockDatabase.query.update().set).not.toHaveBeenCalledWith(expect.objectContaining({ goalRace: expect.any(String) })); // Should not update goalRace
     expect(mockLlmClient.generateResponse).toHaveBeenCalledWith(
-      expect.stringContaining('The user's last response was invalid for the question: "onboarding:goal_race_prompt".'),
+      expect.stringContaining("The user's last response was invalid for the question: \"onboarding:goal_race_prompt\"."),
       undefined,
       "none"
     );


### PR DESCRIPTION
## Summary
- update integration tests to track DB calls via `setMock`
- escape apostrophe in onboarding agent unit test
- adjust integration test to reflect stepwise DB updates
- add conversation history to skip questions test

## Testing
- `npx vitest run __tests__/onboarding-integration.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6873fdebba788328a0bde539a628cbd5