### PR TITLE
Fix build and add log filtering docs

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -247,6 +247,16 @@ railway logs --filter error
 railway logs --follow
 ```
 
+### Log Filtering Syntax
+Railway's log viewer supports advanced filtering across Build, Deploy and HTTP logs:
+
+- Use quotes (`"error"`) for exact phrases.
+- Group expressions with parentheses, e.g. `(db OR redis)`.
+- Combine terms with `AND`/`OR`.
+- Exclude terms with a leading `-`, such as `-debug`.
+
+These filters make it easier to pinpoint relevant events.
+
 ## 📈 Scaling Considerations
 
 ### Horizontal Scaling

--- a/apps/api-gateway/src/flows/enhanced-main-flow.ts
+++ b/apps/api-gateway/src/flows/enhanced-main-flow.ts
@@ -3,7 +3,7 @@ import { injectable, inject, container } from 'tsyringe';
 import { addKeyword, EVENTS } from '@builderbot/bot';
 import { Database, users } from '@running-coach/database';
 import { eq } from 'drizzle-orm';
-import { LanguageDetector } from '@running-coach/shared';
+import { LanguageDetector, UserProfile } from '@running-coach/shared';
 import { AIAgent } from '@running-coach/llm-orchestrator';
 import { VectorMemory } from '@running-coach/vector-memory';
 import logger from '../services/logger-service.js';
@@ -101,7 +101,15 @@ export class EnhancedMainFlow {
             const aiResponse = await this.aiAgent.processMessage({
               userId: ctx.from,
               message,
-              userProfile: user
+              userProfile: {
+                ...user,
+                age: user.age ?? undefined,
+                goalRace: user.goalRace ?? undefined,
+                experienceLevel: user.experienceLevel ?? undefined,
+                injuryHistory: user.injuryHistory ?? undefined,
+                weeklyMileage: user.weeklyMileage ?? undefined,
+                timezone: user.timezone ?? undefined
+              } as UserProfile
             });
             
             response = aiResponse.content;

--- a/instructions/RunningCoach_Architecture.md
+++ b/instructions/RunningCoach_Architecture.md
@@ -131,6 +131,13 @@ const response = await deepSeekAgent.process({
 * Integración de analítica avanzada (TimescaleDB). 
 * Soporte multi-dominio reutilizando `llm-orchestrator`.
 
+### Monitoring and Logs
+Railway muestra registros de build, despliegue y HTTP. Puedes filtrar eventos con:
+- Frases exactas entre comillas (`"error"`).
+- Agrupaciones con paréntesis `(db OR redis)`.
+- Operadores `AND` y `OR`.
+- Exclusiones anteponiendo `-`, por ejemplo `-debug`.
+
 ---
 
 > Documento generado automáticamente por Cascade para reflejar el estado arquitectónico al 27-Jun-2025.


### PR DESCRIPTION
## Summary
- normalize optional user fields when calling AI agent to fix TypeScript build error
- document advanced log filtering syntax in deployment guide
- mention log filtering in architecture instructions

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68746dffb2a88328bca429dcacaf87e2